### PR TITLE
Remove dali.core

### DIFF
--- a/src/cljx/dali/syntax.clj
+++ b/src/cljx/dali/syntax.clj
@@ -2,7 +2,6 @@
   (:require [clojure.java.io :as io]
             [clojure.pprint :refer [cl-format]]
             [clojure.string :as string]
-            [dali.core :as core]
             [hiccup.core :as hiccup]
             [hiccup.page]))
 


### PR DESCRIPTION
When i attempt to use `(require '[dali.syntax :as s])` as per the Readme i get the following error
`CompilerException java.io.FileNotFoundException: Could not locate dali/core__init.class or dali/core.clj on classpath: , compiling:(dali/syntax.clj:1:1)` and  I believe this namespace issue is causing the problem.

An easy to use SVG library is a great addition to the clojure ecosystem - thanks!
